### PR TITLE
update bignum dependency for later node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "mocha": "^1.21.4"
   },
   "dependencies": {
-    "bignum": "^0.11.0"
+    "bignum": "^0.13.0"
   }
 }


### PR DESCRIPTION
I don't remember what I used this for but remember having to update the dependency to a later version.