### PR TITLE
Prevent export override

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
 var crt = require('./chinese_remainder.js');
-
-module.exports = crt;
-
 var crt_bignum = require('./chinese_remainder_bignum.js');
 
-module.exports = crt_bignum;
-
+module.exports = { crt, crt_bignum }


### PR DESCRIPTION
By exporting the modules together. As suggested in https://github.com/pnicorelli/nodejs-chinese-remainder/issues/5
Props for finding the problem and providing a solution to https://github.com/macdja38

Visiting because of the Advent of Code 2020 - Day 13, Part 2 :)

Today I learned about the Chinese Remainder Theorem!
Thanks for creating code to solve it!